### PR TITLE
Fix retry loop in Remove-BSAOvhSms

### DIFF
--- a/Public/Remove-BSAOvhSms.ps1
+++ b/Public/Remove-BSAOvhSms.ps1
@@ -73,16 +73,16 @@ function Remove-BSAOvhSms {
 		foreach ($Id in $SmsId) {
 			Write-Verbose -Message "Processing SMS $Id"
 			$properties.Path = "/sms/$ServiceName/outgoing/$Id"
-			$retry = 5
-			do {
-				$response = Invoke-BSAOvhApiRequest @properties
-				if ($null -eq $response) {
-					Write-Verbose "SMS id $Id deleted"
-					Continue
-				}
-				Write-Verbose -Message "response: $response"
-				$retry--
-			} until ($response.Class -ne 'Client::BadRequest' -and $retry -gt 0)
+                        $retry = 5
+                        do {
+                                $response = Invoke-BSAOvhApiRequest @properties
+                                if ($null -eq $response) {
+                                        Write-Verbose "SMS id $Id deleted"
+                                        break
+                                }
+                                Write-Verbose -Message "response: $response"
+                                $retry--
+                        } until ($response.Class -ne 'Client::BadRequest' -or $retry -le 0)
 		}
 
 		return $true


### PR DESCRIPTION
## Summary
- fix infinite retry loop when deleting SMS

## Testing
- `pwsh -NoLogo -Command "Import-Module ./BSAOvhApi.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f267f6a28832e90a1d4eefb5f1210